### PR TITLE
Experimental

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -35,6 +35,38 @@ struct AnyExecutable
   RCLCPP_PUBLIC
   AnyExecutable();
 
+  /// Constructor (subscription)
+  AnyExecutable (rclcpp::SubscriptionBase::SharedPtr subscription_param,
+    int callback_priority_param,
+    rclcpp::CallbackGroup::SharedPtr callback_group_param,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_param)
+  :
+    subscription(subscription_param),
+    timer(nullptr),
+    service(nullptr),
+    client(nullptr),
+    waitable(nullptr),
+    callback_priority(callback_priority_param),
+    callback_group(callback_group_param),
+    node_base(node_base_param)
+  {}
+
+  /// Constructor (timer)
+  AnyExecutable (rclcpp::TimerBase::SharedPtr timer_param,
+    int callback_priority_param,
+    rclcpp::CallbackGroup::SharedPtr callback_group_param,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_param)
+  :
+    subscription(nullptr),
+    timer(timer_param),
+    service(nullptr),
+    client(nullptr),
+    waitable(nullptr),
+    callback_priority(callback_priority_param),
+    callback_group(callback_group_param),
+    node_base(node_base_param)
+  {}
+
   RCLCPP_PUBLIC
   virtual ~AnyExecutable();
 

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <set>
 
 #include "rcl/guard_condition.h"
 #include "rcl/wait.h"
@@ -295,7 +296,7 @@ protected:
   bool get_next_ready_executable (AnyExecutable &any_executable);
 
   RCLCPP_PUBLIC
-  std::set<AnyExecutable::SharedPtr> *get_all_ready_executables ();
+  std::vector<AnyExecutable> *get_all_ready_executables ();
 
   RCLCPP_PUBLIC
   bool get_highest_priority_ready_executable (AnyExecutable &any_executable);

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -295,6 +295,12 @@ protected:
   bool get_next_ready_executable (AnyExecutable &any_executable);
 
   RCLCPP_PUBLIC
+  std::set<AnyExecutable::SharedPtr> *get_all_ready_executables ();
+
+  RCLCPP_PUBLIC
+  bool get_highest_priority_ready_executable (AnyExecutable &any_executable);
+
+  RCLCPP_PUBLIC
   bool can_run_ready_executable (bool ready, AnyExecutable &any_executable);
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/executors/preemptive_priority_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/preemptive_priority_executor.hpp
@@ -375,7 +375,7 @@ public:
 	PreemptivePriorityExecutor (
 		const rclcpp::ExecutorOptions &options = rclcpp::ExecutorOptions(),
 		thread_priority_range_t priority_range = {50,90},
-		scheduling_policy_t scheduling_policy = NP_FP);
+		scheduling_policy_t scheduling_policy = P_FP);
 
 	/*\
 	 * Destructor for the PreemptivePriorityExecutor
@@ -409,16 +409,6 @@ protected:
 	RCLCPP_PUBLIC
 	JobPriorityQueue *clear_finished_jobs (JobPriorityQueue *queue, 
 		int *n_running_jobs_p);
-
-
-	/*\
-	 * Returns priority assigned to given executable. 
-	 * Note: Services and clients do not yet have priorities. Returns -1 for them
-	 * \param any_executable Reference to executable 
-	 * \return Integer describing priority
-	\*/
-	RCLCPP_PUBLIC
-	int get_executable_priority (AnyExecutable &any_executable);
 
 	/*\
 	 * Runs a callback. This should be run within a worker thread at a lower priority
@@ -456,6 +446,12 @@ protected:
 	\*/
 	RCLCPP_PUBLIC
 	std::set<SubscriptionBase::SharedPtr> *scheduled_subscriptions ();
+
+	/*\
+	 * Returns a string object describing the executor mode and priority ranges
+	 * \return String describing executor
+	\*/
+	std::string description ();
 
 private:
 

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -17,6 +17,7 @@
 
 #include <list>
 #include <memory>
+#include <set>
 
 #include "rcl/allocator.h"
 #include "rcl/wait.h"
@@ -87,17 +88,17 @@ public:
 
   virtual void 
   get_all_ready_timers (
-    std::set<AnyExecutable::SharedPtr> *ready_set_p,
+    std::vector<AnyExecutable> *ready_vector_p,
+    const WeakNodeList & weak_nodes) = 0;
+
+  virtual void 
+  get_all_ready_subscriptions (
+    std::vector<AnyExecutable> *ready_vector_p,
     const WeakNodeList & weak_nodes) = 0;
 
   virtual void 
   get_highest_priority_timer_or_subscription(
     rclcpp::AnyExecutable & any_exec,
-    const WeakNodeList & weak_nodes) = 0;
-
-  virtual void 
-  get_all_ready_subscriptions (
-    std::set<AnyExecutable::SharedPtr> *ready_set_p,
     const WeakNodeList & weak_nodes) = 0;
 
   virtual void

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -85,6 +85,21 @@ public:
     rclcpp::AnyExecutable & any_exec,
     const WeakNodeList & weak_nodes) = 0;
 
+  virtual void 
+  get_all_ready_timers (
+    std::set<AnyExecutable::SharedPtr> *ready_set_p,
+    const WeakNodeList & weak_nodes) = 0;
+
+  virtual void 
+  get_highest_priority_timer_or_subscription(
+    rclcpp::AnyExecutable & any_exec,
+    const WeakNodeList & weak_nodes) = 0;
+
+  virtual void 
+  get_all_ready_subscriptions (
+    std::set<AnyExecutable::SharedPtr> *ready_set_p,
+    const WeakNodeList & weak_nodes) = 0;
+
   virtual void
   get_next_waitable(
     rclcpp::AnyExecutable & any_exec,

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -657,17 +657,17 @@ bool Executor::get_next_ready_executable (AnyExecutable &any_executable)
 	return can_run_ready_executable(false, any_executable);
 }
 
-std::set<AnyExecutable::SharedPtr> *get_all_ready_executables ()
+std::vector<AnyExecutable> *Executor::get_all_ready_executables ()
 {
-	std::set<AnyExecutable::SharedPtr> *ready_set_p = new std::set<AnyExecutable::SharedPtr>();
+	std::vector<AnyExecutable> *ready_vector_p = new std::vector<AnyExecutable>();
 
 	// Insert all ready timers
-	get_all_ready_timers(ready_set_p, weak_nodes_);
+	memory_strategy_->get_all_ready_timers(ready_vector_p, weak_nodes_);
 
 	// Insert all ready subscriptions
-	get_all_ready_subscriptions(ready_set_p, weak_nodes_);
+	memory_strategy_->get_all_ready_subscriptions(ready_vector_p, weak_nodes_);
 
-	return ready_set_p;
+	return ready_vector_p;
 }
 
 bool Executor::get_highest_priority_ready_executable (AnyExecutable &any_executable)

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -627,25 +627,25 @@ bool Executor::get_next_ready_executable (AnyExecutable &any_executable)
 	// 1. Check if any timers are ready
 	memory_strategy_->get_next_timer(any_executable, weak_nodes_);
 	if (any_executable.timer) {
-		return can_run_ready_executable(true, any_executable);;
+		return can_run_ready_executable(true, any_executable);
 	}
 
 	// 2. Check if any subscriptions are ready
 	memory_strategy_->get_next_subscription(any_executable, weak_nodes_);
 	if (any_executable.subscription) {
-		return can_run_ready_executable(true, any_executable);;
+		return can_run_ready_executable(true, any_executable);
 	}
 
 	// 3. Check if any services are ready
 	memory_strategy_->get_next_service(any_executable, weak_nodes_);
 	if (any_executable.service) {
-		return can_run_ready_executable(true, any_executable);;
+		return can_run_ready_executable(true, any_executable);
 	}
 
 	// 4. Check if any clients are ready
 	memory_strategy_->get_next_client(any_executable, weak_nodes_);
 	if (any_executable.client) {
-		return can_run_ready_executable(true, any_executable);;
+		return can_run_ready_executable(true, any_executable);
 	}
 
 	// 5. Check for waitables
@@ -655,6 +655,26 @@ bool Executor::get_next_ready_executable (AnyExecutable &any_executable)
 	}
 
 	return can_run_ready_executable(false, any_executable);
+}
+
+std::set<AnyExecutable::SharedPtr> *get_all_ready_executables ()
+{
+	std::set<AnyExecutable::SharedPtr> *ready_set_p = new std::set<AnyExecutable::SharedPtr>();
+
+	// Insert all ready timers
+	get_all_ready_timers(ready_set_p, weak_nodes_);
+
+	// Insert all ready subscriptions
+	get_all_ready_subscriptions(ready_set_p, weak_nodes_);
+
+	return ready_set_p;
+}
+
+bool Executor::get_highest_priority_ready_executable (AnyExecutable &any_executable)
+{
+	memory_strategy_->get_highest_priority_timer_or_subscription(any_executable, weak_nodes_);
+	bool ready = ((nullptr != any_executable.subscription) || (nullptr != any_executable.timer));
+	return can_run_ready_executable(ready, any_executable);
 }
 
 bool Executor::can_run_ready_executable (bool ready, AnyExecutable &any_executable)


### PR DESCRIPTION
Merging fixes to the executor design: 

1. Grabbing all ready executables instead of using the build-in `get_ready_executable` method, which did not perform as expected due to bizarre behavior from timers not disappearing from the ready set even when 'taken'.
2. Changed the default priority back to preemptive fixed-priority. It had been changed during experimentation and forgot to change it back. 
3. Rewrote the executor main loop to process all elements it gets instead of just one next ready executable
4. Moved the queue clearing until after elements have been added to make debugging more sensible. 
5. Added a color printed banner to indicate the mode of the executor to avoid accidents where I am testing in a mode I didn't expect. 