### PR TITLE
Extended spin_some for the MultiThreadedExecutor class

### DIFF
--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -70,6 +70,10 @@ public:
   spin() override;
 
   RCLCPP_PUBLIC
+  void
+  spin_some(std::chrono::nanoseconds max_duration = std::chrono::nanoseconds(0)) override;
+
+  RCLCPP_PUBLIC
   size_t
   get_number_of_threads();
 
@@ -77,6 +81,9 @@ protected:
   RCLCPP_PUBLIC
   void
   run(size_t this_thread_number);
+  RCLCPP_PUBLIC
+  void
+  run_some(size_t this_thread_number, std::chrono::nanoseconds max_duration);
 
 private:
   RCLCPP_DISABLE_COPY(MultiThreadedExecutor)

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -65,6 +65,33 @@ MultiThreadedExecutor::spin()
   }
 }
 
+void
+MultiThreadedExecutor::spin_some(std::chrono::nanoseconds max_duration)
+{
+  std::cout << "MultiThreadedExecutor::spin_some()" << std::endl;
+  // Check that the executor isn't already spinning
+  if (spinning.exchange(true)) {
+    throw std::runtime_error("spin_some() called while already spinning");
+  }
+  RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
+  std::vector<std::thread> threads;
+
+  // Create all threads
+  size_t thread_id = 0;
+  {
+    std::lock_guard<std::mutex> wait_lock(wait_mutex_);
+    for (; thread_id < (number_of_threads_ - 1); ++thread_id) {
+      auto func = std::bind(&MultiThreadedExecutor::run_some, this, thread_id, max_duration);
+      threads.emplace_back(func);
+    }
+  }
+
+  run_some(thread_id, max_duration);
+  for (auto & thread : threads) {
+    thread.join();
+  }
+}
+
 size_t
 MultiThreadedExecutor::get_number_of_threads()
 {
@@ -114,4 +141,69 @@ MultiThreadedExecutor::run(size_t)
     // resetting the callback group `can_be_taken_from`
     any_exec.callback_group.reset();
   }
+}
+
+void 
+MultiThreadedExecutor::run_some(size_t thread_id, std::chrono::nanoseconds max_duration)
+{
+
+  // Fetch and store current timestamp
+  auto start = std::chrono::steady_clock::now();
+
+  // Callback to determine if the duration has expired
+  auto callback_should_still_spin = [max_duration, start]()
+  {
+    // Case: Spin forever
+    if (std::chrono::nanoseconds(0) == max_duration) {
+      return true;
+    }
+
+    // Case: Spin for duration
+    return ((std::chrono::steady_clock::now() - start) < max_duration);
+  };
+
+  while (rclcpp::ok(this->context_) && spinning.load() && 
+    true == callback_should_still_spin())
+  {
+    rclcpp::AnyExecutable any_exec;
+    {
+      std::lock_guard<std::mutex> wait_lock(wait_mutex_);
+      if (!rclcpp::ok(this->context_) || !spinning.load()) {
+        return;
+      }
+      if (!get_next_executable(any_exec, next_exec_timeout_)) {
+        continue;
+      }
+      if (any_exec.timer) {
+        // Guard against multiple threads getting the same timer.
+        if (scheduled_timers_.count(any_exec.timer) != 0) {
+          // Make sure that any_exec's callback group is reset before
+          // the lock is released.
+          if (any_exec.callback_group) {
+            any_exec.callback_group->can_be_taken_from().store(true);
+          }
+          continue;
+        }
+        scheduled_timers_.insert(any_exec.timer);
+      }
+    }
+    if (yield_before_execute_) {
+      std::this_thread::yield();
+    }
+
+    execute_any_executable(any_exec);
+
+    if (any_exec.timer) {
+      std::lock_guard<std::mutex> wait_lock(wait_mutex_);
+      auto it = scheduled_timers_.find(any_exec.timer);
+      if (it != scheduled_timers_.end()) {
+        scheduled_timers_.erase(it);
+      }
+    }
+    // Clear the callback_group to prevent the AnyExecutable destructor from
+    // resetting the callback group `can_be_taken_from`
+    any_exec.callback_group.reset();
+  }
+
+  std::cout << "Thread " << thread_id << " done..." << std::endl;
 }


### PR DESCRIPTION
The `spin_some` method is implemented in the `executor` subclass, and applies to `SingleThreadedExecutor`. However, a suitable implementation does **not** exist for the `MultiThreadedExecutor`. This has been extended to apply to `MultiThreadedExecutor`.