### PR TITLE
Merging executor overhaul.

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -48,7 +48,8 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/expand_topic_or_service_name.cpp
   src/rclcpp/executors/multi_threaded_executor.cpp
   src/rclcpp/executors/single_threaded_executor.cpp
-  src/rclcpp/executors/preemptive_priority_executor.cpp
+  src/rclcpp/executors/producer_consumer_executor.cpp
+  src/rclcpp/executors/thread_dispatch_executor.cpp
   src/rclcpp/executors/static_executor_entities_collector.cpp
   src/rclcpp/executors/static_single_threaded_executor.cpp
   src/rclcpp/future_return_code.cpp

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -40,6 +40,11 @@
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/scope_exit.hpp"
 
+
+// If defined, custom profiling code is used
+// #define PROFILE
+
+
 namespace rclcpp
 {
 
@@ -295,6 +300,11 @@ protected:
   RCLCPP_PUBLIC
   bool get_next_ready_executable (AnyExecutable &any_executable);
 
+#ifdef PROFILE
+  RCLCPP_PUBLIC
+  bool get_next_ready_executable (AnyExecutable &any_executable, long long *overhead_ns_ptr);
+#endif
+
   RCLCPP_PUBLIC
   std::vector<AnyExecutable> *get_all_ready_executables ();
 
@@ -306,6 +316,12 @@ protected:
 
   RCLCPP_PUBLIC
   bool get_next_executable (AnyExecutable &any_executable, std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
+
+#ifdef PROFILE
+  RCLCPP_PUBLIC
+  bool get_next_executable (AnyExecutable &any_executable, long long *overhead_ns_ptr, 
+    std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
+#endif
 
   /// Spinning state, used to prevent multi threaded calls to spin and to cancel blocking spins.
   std::atomic_bool spinning;

--- a/rclcpp/include/rclcpp/executor_base.hpp
+++ b/rclcpp/include/rclcpp/executor_base.hpp
@@ -1,0 +1,206 @@
+#ifndef EXECUTOR_BASE
+#define EXECUTOR_BASE
+
+// Standard headers
+#include <iostream>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <pthread.h>
+#include <future>
+#include <cstring>
+#include <map>
+#include <queue>
+#include <unordered_set>
+#include <functional>
+#include <sched.h>
+
+// RCLCPP headers
+#include "rclcpp/executor.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp 
+{
+namespace executors 
+{
+
+/*
+ *******************************************************************************
+ *                              Type Definitions                               *
+ *******************************************************************************
+*/
+
+
+// Range of priorities the executor may use for threads: [l_bound, u_bound]
+typedef struct {
+	int l_bound;
+	int u_bound;
+} thread_priority_range_t;
+
+// Enumeration of (supported) callback types
+typedef enum {
+	CALLBACK_TIMER,
+	CALLBACK_SUBSCRIPTION,
+} callback_t;
+
+
+/*
+ *******************************************************************************
+ *                         Complete Class Definitions                          *
+ *******************************************************************************
+*/
+
+
+class Callback {
+public:
+	Callback (rclcpp::SubscriptionBase::SharedPtr s, 
+		      rclcpp::CallbackGroup::SharedPtr callback_group,
+		      rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base):
+		d_callback_type(CALLBACK_SUBSCRIPTION),
+		d_callback_group(callback_group),
+		d_node_base(node_base),
+		d_subscription(s)
+	{
+
+		// TODO: Add support for serialized and loaned messages
+		if (s->is_serialized() || s->can_loan_messages()) {
+			throw std::runtime_error(std::string("Received serialized or loan(able) message!"));
+		}
+
+		// Get message metadata (timestamps, etc)
+		d_subscription_message_info.get_rmw_message_info().from_intra_process = false;
+
+		// Obtain a dynamically allocated message using the allocator strategy
+		d_subscription_message = s->create_message();
+
+		try {
+			s->take_type_erased(d_subscription_message.get(), d_subscription_message_info);
+		} catch (const rclcpp::exceptions::RCLError &rcl_error) {
+			throw std::runtime_error(std::string("Executor failed to take copied message for topic: \"") +
+				std::string(s->get_topic_name()) + std::string("\" RCL: ") + 
+				std::string(rcl_error.what()));
+		}
+
+		// Calls: handle_message and return_message will be invoked when execution needed
+	}
+
+	Callback (rclcpp::TimerBase::SharedPtr t,
+		      rclcpp::CallbackGroup::SharedPtr callback_group,
+		      rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base):
+		d_callback_type(CALLBACK_TIMER),
+		d_callback_group(callback_group),
+		d_node_base(node_base),
+		d_subscription(nullptr),
+		d_timer(t)
+	{
+		// execute_callback() in class GenericTimer in timer.hpp implements the CB for RCL timers
+		// it calls rcl_timer_call, but you should only call that if the period has elapsed yet
+		// and are responsible to tracking this.
+		// I don't want to make the call yet, so postpone this decision
+	}
+
+	// Move constructor
+	Callback (const Callback &&other)
+	{
+		d_callback_type = other.d_callback_type;
+		d_callback_group = std::move(other.d_callback_group);
+		d_node_base = std::move(other.d_node_base);
+		d_subscription = std::move(other.d_subscription);
+		d_timer = std::move(other.d_timer);
+		d_subscription_message_info = other.d_subscription_message_info;
+		d_subscription_message = std::move(other.d_subscription_message);
+	}
+
+	void execute ()
+	{
+		switch (d_callback_type) {
+			case CALLBACK_TIMER: {
+				this->execute_timer();
+			}
+			break;
+
+			case CALLBACK_SUBSCRIPTION: {
+				this->execute_subscription();
+			}
+			break;
+		}
+	}
+
+	std::string description ()
+	{
+		switch (d_callback_type) {
+			case CALLBACK_TIMER: {
+				return std::string("timer");
+			}
+			case CALLBACK_SUBSCRIPTION: {
+				return std::string("sub(") + std::string(d_subscription->get_topic_name())
+					+ std::string(")");
+			}
+		}
+		return std::string("unknown");
+	}
+
+	callback_t callback_type ()
+	{
+		return d_callback_type;
+	}
+
+	rclcpp::CallbackGroup::SharedPtr callback_group ()
+	{
+		return d_callback_group;
+	}
+
+	rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base ()
+	{
+		return d_node_base;
+	}
+
+	rclcpp::SubscriptionBase::SharedPtr subscription ()
+	{
+		return d_subscription;
+	}
+
+	rclcpp::TimerBase::SharedPtr timer ()
+	{
+		return d_timer;
+	}
+
+protected:
+	void execute_subscription ()
+	{
+		d_subscription->handle_message(d_subscription_message, d_subscription_message_info);
+		d_subscription->return_message(d_subscription_message);
+	}
+
+	void execute_timer ()
+	{
+		d_timer->execute_callback();
+	}
+
+private:
+
+	// Identifies type of callback
+	callback_t d_callback_type;
+
+	// Executable metadata
+	rclcpp::CallbackGroup::SharedPtr d_callback_group;
+	rclcpp::node_interfaces::NodeBaseInterface::SharedPtr d_node_base;
+
+	// Subscription
+	rclcpp::SubscriptionBase::SharedPtr d_subscription;
+
+	// Timer
+	rclcpp::TimerBase::SharedPtr d_timer;
+
+	// Subscription metadata
+	rclcpp::MessageInfo d_subscription_message_info;
+	std::shared_ptr<void> d_subscription_message;
+
+};
+
+}
+}
+
+#endif

--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -21,7 +21,8 @@
 #include "rclcpp/executors/multi_threaded_executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/executors/static_single_threaded_executor.hpp"
-#include "rclcpp/executors/preemptive_priority_executor.hpp"
+#include "rclcpp/executors/producer_consumer_executor.hpp"
+#include "rclcpp/executors/thread_dispatch_executor.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -54,7 +55,8 @@ namespace executors
 
 using rclcpp::executors::MultiThreadedExecutor;
 using rclcpp::executors::SingleThreadedExecutor;
-using rclcpp::executors::PreemptivePriorityExecutor;
+using rclcpp::executors::PPE::ProducerConsumerExecutor;
+using rclcpp::executors::PPE::ThreadDispatchExecutor;
 
 /// Spin (blocking) until the future is complete, it times out waiting, or rclcpp is interrupted.
 /**

--- a/rclcpp/include/rclcpp/executors/producer_consumer_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/producer_consumer_executor.hpp
@@ -1,5 +1,5 @@
-#ifndef PREEMPTIVE_PRIORITY_EXECUTOR
-#define PREEMPTIVE_PRIORITY_EXECUTOR
+#ifndef PRODUCER_CONSUMER_EXECUTOR
+#define PRODUCER_CONSUMER_EXECUTOR
 
 
 // Standard headers
@@ -22,10 +22,15 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
 
+// Custom headers
+#include "rclcpp/executor_base.hpp"
+
 
 namespace rclcpp
 {
 namespace executors
+{
+namespace PPE
 {
 
 
@@ -37,25 +42,13 @@ namespace executors
 
 
 // Forward class declarations
-class PreemptivePriorityExecutor;
-class Callback;
+class ProducerConsumerExecutor;
 
 // Directives
+using rclcpp::executors::Callback;
+using rclcpp::executors::thread_priority_range_t;
+using rclcpp::executors::callback_t;
 using Callback_Ptr = std::shared_ptr<Callback>;
-
-
-// Range of priorities the executor may use for threads: [l_bound, u_bound]
-typedef struct {
-	int l_bound;
-	int u_bound;
-} thread_priority_range_t;
-
-
-// Enumeration of (supported) callback types
-typedef enum {
-	CALLBACK_TIMER,
-	CALLBACK_SUBSCRIPTION,
-} callback_t;
 
 
 /*
@@ -63,154 +56,6 @@ typedef enum {
  *                         Complete Class Definitions                          *
  *******************************************************************************
 */
-
-
-class Callback {
-public:
-	Callback (rclcpp::SubscriptionBase::SharedPtr s, 
-		      rclcpp::CallbackGroup::SharedPtr callback_group,
-		      rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base):
-		d_callback_type(CALLBACK_SUBSCRIPTION),
-		d_callback_group(callback_group),
-		d_node_base(node_base),
-		d_subscription(s)
-	{
-
-		// TODO: Add support for serialized and loaned messages
-		if (s->is_serialized() || s->can_loan_messages()) {
-			throw std::runtime_error(std::string("Received serialized or loan(able) message!"));
-		}
-
-		// Get message metadata (timestamps, etc)
-		d_subscription_message_info.get_rmw_message_info().from_intra_process = false;
-
-		// Obtain a dynamically allocated message using the allocator strategy
-		d_subscription_message = s->create_message();
-
-		try {
-			s->take_type_erased(d_subscription_message.get(), d_subscription_message_info);
-		} catch (const rclcpp::exceptions::RCLError &rcl_error) {
-			throw std::runtime_error(std::string("Executor failed to take copied message for topic: \"") +
-				std::string(s->get_topic_name()) + std::string("\" RCL: ") + 
-				std::string(rcl_error.what()));
-		}
-
-		// Calls: handle_message and return_message will be invoked when execution needed
-	}
-
-	Callback (rclcpp::TimerBase::SharedPtr t,
-		      rclcpp::CallbackGroup::SharedPtr callback_group,
-		      rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base):
-		d_callback_type(CALLBACK_TIMER),
-		d_callback_group(callback_group),
-		d_node_base(node_base),
-		d_subscription(nullptr),
-		d_timer(t)
-	{
-		// execute_callback() in class GenericTimer in timer.hpp implements the CB for RCL timers
-		// it calls rcl_timer_call, but you should only call that if the period has elapsed yet
-		// and are responsible to tracking this.
-		// I don't want to make the call yet, so postpone this decision
-	}
-
-	// Move constructor
-	Callback (const Callback &&other)
-	{
-		d_callback_type = other.d_callback_type;
-		d_callback_group = std::move(other.d_callback_group);
-		d_node_base = std::move(other.d_node_base);
-		d_subscription = std::move(other.d_subscription);
-		d_timer = std::move(other.d_timer);
-		d_subscription_message_info = other.d_subscription_message_info;
-		d_subscription_message = std::move(other.d_subscription_message);
-	}
-
-	void execute ()
-	{
-		switch (d_callback_type) {
-			case CALLBACK_TIMER: {
-				this->execute_timer();
-			}
-			break;
-
-			case CALLBACK_SUBSCRIPTION: {
-				this->execute_subscription();
-			}
-			break;
-		}
-	}
-
-	std::string description ()
-	{
-		switch (d_callback_type) {
-			case CALLBACK_TIMER: {
-				return std::string("timer");
-			}
-			case CALLBACK_SUBSCRIPTION: {
-				return std::string("sub(") + std::string(d_subscription->get_topic_name())
-					+ std::string(")");
-			}
-		}
-		return std::string("unknown");
-	}
-
-	callback_t callback_type ()
-	{
-		return d_callback_type;
-	}
-
-	rclcpp::CallbackGroup::SharedPtr callback_group ()
-	{
-		return d_callback_group;
-	}
-
-	rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base ()
-	{
-		return d_node_base;
-	}
-
-	rclcpp::SubscriptionBase::SharedPtr subscription ()
-	{
-		return d_subscription;
-	}
-
-	rclcpp::TimerBase::SharedPtr timer ()
-	{
-		return d_timer;
-	}
-
-protected:
-	void execute_subscription ()
-	{
-		d_subscription->handle_message(d_subscription_message, d_subscription_message_info);
-		d_subscription->return_message(d_subscription_message);
-	}
-
-	void execute_timer ()
-	{
-		d_timer->execute_callback();
-	}
-
-private:
-
-	// Identifies type of callback
-	callback_t d_callback_type;
-
-	// Executable metadata
-	rclcpp::CallbackGroup::SharedPtr d_callback_group;
-	rclcpp::node_interfaces::NodeBaseInterface::SharedPtr d_node_base;
-
-	// Subscription
-	rclcpp::SubscriptionBase::SharedPtr d_subscription;
-
-	// Timer
-	rclcpp::TimerBase::SharedPtr d_timer;
-
-	// Subscription metadata
-	rclcpp::MessageInfo d_subscription_message_info;
-	std::shared_ptr<void> d_subscription_message;
-
-};
 
 
 /*\
@@ -346,10 +191,10 @@ public:
  * relies on the OS scheduler to provide preemption. 
  * Work to be done with equal priority is executed in FIFO order
  */
-class PreemptivePriorityExecutor : public rclcpp::Executor
+class ProducerConsumerExecutor : public rclcpp::Executor
 {
 public:
-	RCLCPP_SMART_PTR_DEFINITIONS(PreemptivePriorityExecutor)
+	RCLCPP_SMART_PTR_DEFINITIONS(ProducerConsumerExecutor)
 
 	/*\
 	 * Creates an instance of the preemptive-priority executor.
@@ -357,7 +202,7 @@ public:
 	 * \param priority_range Range of OS priorities to use
 	\*/
 	RCLCPP_PUBLIC
-	PreemptivePriorityExecutor (
+	ProducerConsumerExecutor (
 		const rclcpp::ExecutorOptions &options = rclcpp::ExecutorOptions(),
 		thread_priority_range_t priority_range = {95,99});
 
@@ -365,7 +210,7 @@ public:
 	 * Destructor
 	\*/
 	RCLCPP_PUBLIC
-	~PreemptivePriorityExecutor();
+	~ProducerConsumerExecutor();
 
 	/*\
 	 * Multiplexes callbacks as described in class description
@@ -449,7 +294,7 @@ private:
 	std::unordered_set<SubscriptionBase::SharedPtr> d_handled_subscriptions;
 };
 
-
+}
 }
 }
 

--- a/rclcpp/include/rclcpp/executors/thread_dispatch_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/thread_dispatch_executor.hpp
@@ -1,0 +1,184 @@
+#ifndef THREAD_DISPATCH_EXECUTOR
+#define THREAD_DISPATCH_EXECUTOR
+
+
+// Standard headers
+#include <iostream>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <pthread.h>
+#include <future>
+#include <cstring>
+#include <map>
+#include <queue>
+#include <unordered_set>
+#include <functional>
+#include <sched.h>
+
+// RCLCPP headers
+#include "rclcpp/executor.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+// Custom headers
+#include "rclcpp/executor_base.hpp"
+
+namespace rclcpp
+{
+namespace executors
+{
+namespace PPE 
+{
+
+
+/*
+ *******************************************************************************
+ *                              Type Definitions                               *
+ *******************************************************************************
+*/
+
+
+// Forward class declarations
+class ThreadDispatchExecutor;
+
+// Directives
+using rclcpp::executors::Callback;
+using rclcpp::executors::thread_priority_range_t;
+using rclcpp::executors::callback_t;
+using Callback_Ptr = std::shared_ptr<Callback>;
+
+
+/*
+ *******************************************************************************
+ *                             Class Declarations                              *
+ *******************************************************************************
+*/
+
+
+/// A multi-threaded executor with support for preemption and callback priority.
+/**
+ * This class declares the thread dispatch executor. This executor is
+ * multi-threaded and designed to be run on two cores. 
+ *
+ * All threads are setup to run with the Linux real-time FIFO scheduler, and 
+ * in the following configuration:
+ *
+ * Core 0: Multiplexer thread, at maximum priority P
+ * Core 1: Work threads, at priorities < P
+ *
+ * The executor launches work-threads with priority values in the range [a,b),
+ * with it taking the highest priority value b. Each arriving callback has a 
+ * dedicated thread dispatched for it, and that thread takes on the priority
+ * value of the callback. Once the threads are finished, they destroy themselves.
+ *
+ * The executor relies on the OS scheduler to provide preemption. 
+ * Work to be done with equal priority is executed in FIFO order
+ */
+class ThreadDispatchExecutor : public rclcpp::Executor
+{
+public:
+	RCLCPP_SMART_PTR_DEFINITIONS(ThreadDispatchExecutor)
+
+	/*\
+	 * Creates an instance of the thread-dispatch executor.
+	 * \param options Common executor options
+	 * \param priority_range Range of OS priorities to use
+	\*/
+	RCLCPP_PUBLIC
+	ThreadDispatchExecutor (
+		const rclcpp::ExecutorOptions &options = rclcpp::ExecutorOptions(),
+		thread_priority_range_t priority_range = {95,99});
+
+	/*\
+	 * Destructor
+	\*/
+	RCLCPP_PUBLIC
+	~ThreadDispatchExecutor();
+
+	/*\
+	 * Multiplexes callbacks as described in class description
+	\*/
+	RCLCPP_PUBLIC
+	void spin() override;
+
+	/*\
+	 * Multiplexes callbacks as described in class description,
+	 * but runs only until the given duration has expired.
+	 * Note: Work threads may take more time to finish, as they
+	 * cannot stop when busy executing a callback, or may be 
+	 * sleeping (in which case they close down after waking
+	 * routinely according to a set timeout)
+	\*/
+	RCLCPP_PUBLIC
+	void spin_some (std::chrono::nanoseconds max_duration =
+		std::chrono::nanoseconds(0)) override;
+
+protected:
+
+	/*\
+	 * Main loop function for a dispatch thread. This 
+	 * thread executes its callback and then destroys
+	 * itself
+	\*/
+	RCLCPP_PUBLIC
+	static void run (rclcpp::executors::PPE::ThreadDispatchExecutor *executor, 
+		Callback_Ptr callback);
+
+	/*\
+	 * Main loop function for an executor thread. This
+	 * thread multiplexes callbacks and dispatches 
+	 * threads to fulfill them
+	\*/
+	RCLCPP_PUBLIC
+	void multiplex (std::chrono::nanoseconds max_duration);
+
+
+	/*\
+	 * Moves an AnyExecutable instance into a callback
+	 * wrapper. The callback wrapper is only created
+	 * if the executable (subscription/timer) has not
+	 * already been handled. I'm not sure why this behavior
+	 * exists, but without this duplicate callbacks can appear
+	 * in the wait-set.
+	\*/
+	RCLCPP_PUBLIC
+	Callback_Ptr executable_to_callback (AnyExecutable e);
+
+	/*\
+	 * Removes the given executable (timer/subscription)
+	 * from the internal sets tracking which executables are
+	 * currently already being handled.
+	\*/
+	RCLCPP_PUBLIC
+	void remove_expired_executable (Callback_Ptr callback);
+
+
+	/*\
+	 * Returns a string describing the executor
+	\*/
+	RCLCPP_PUBLIC
+	std::string description();
+
+private:
+
+	// Configuration fields
+	thread_priority_range_t d_priority_range;
+
+	// Control mutexes
+	std::mutex d_timer_set_mutex;
+	std::mutex d_subscription_set_mutex;
+
+	// Set containing already-handled timers
+	std::unordered_set<TimerBase::SharedPtr> d_handled_timers;
+
+	// Set containing already-handled subscriptions
+	std::unordered_set<SubscriptionBase::SharedPtr> d_handled_subscriptions;
+};
+
+}
+}
+}
+
+#endif

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -193,8 +193,10 @@ public:
    * \param[in] topic_name The topic to subscribe on.
    * \param[in] qos QoS profile for Subcription.
    * \param[in] callback The user-defined callback function to receive a message
+   * \param[in] callback_priority The user-defined callback priority level
    * \param[in] options Additional options for the creation of the Subscription.
    * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
+   * \param[in] callback_priority Priority value for use with preemptive executors
    * \return Shared pointer to the created subscription.
    */
   template<
@@ -222,31 +224,6 @@ public:
     const int callback_priority = -1
   );
 
-
-  template<
-    typename MessageT,
-    typename CallbackT,
-    typename AllocatorT = std::allocator<void>,
-    typename CallbackMessageT =
-    typename rclcpp::subscription_traits::has_message_type<CallbackT>::type,
-    typename SubscriptionT = rclcpp::Subscription<CallbackMessageT, AllocatorT>,
-    typename MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
-      CallbackMessageT,
-      AllocatorT
-    >
-  >
-  std::shared_ptr<SubscriptionT>
-  create_priority_subscription(
-    const std::string & topic_name,
-    const rclcpp::QoS & qos,
-    CallbackT && callback,
-    const int callback_priority,
-    const SubscriptionOptionsWithAllocator<AllocatorT> & options =
-    SubscriptionOptionsWithAllocator<AllocatorT>(),
-    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
-      MessageMemoryStrategyT::create_default()
-    )
-  );
   /// Create a timer.
   /**
    * \param[in] period Time interval between triggers of the callback.

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -106,32 +106,6 @@ Node::create_subscription(
     callback_priority);
 }
 
-template<
-  typename MessageT,
-  typename CallbackT,
-  typename AllocatorT,
-  typename CallbackMessageT,
-  typename SubscriptionT,
-  typename MessageMemoryStrategyT>
-std::shared_ptr<SubscriptionT>
-Node::create_priority_subscription(
-  const std::string & topic_name,
-  const rclcpp::QoS & qos,
-  CallbackT && callback,
-  const int callback_priority,
-  const SubscriptionOptionsWithAllocator<AllocatorT> & options,
-  typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
-{
-  return rclcpp::create_subscription<MessageT>(
-    *this,
-    extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
-    qos,
-    std::forward<CallbackT>(callback),
-    options,
-    msg_mem_strat,
-    callback_priority);
-}
-
 template<typename DurationRepT, typename DurationT, typename CallbackT>
 typename rclcpp::WallTimer<CallbackT>::SharedPtr
 Node::create_wall_timer(

--- a/rclcpp/src/rclcpp/executors/thread_dispatch_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/thread_dispatch_executor.cpp
@@ -1,0 +1,335 @@
+
+// File header
+#include "rclcpp/executors/thread_dispatch_executor.hpp"
+
+// Standard headers
+#include <chrono>
+#include <functional>
+#include <vector>
+#include <memory>
+
+// RCLCPP headers
+#include "rclcpp/utilities.hpp"
+#include "rclcpp/scope_exit.hpp"
+
+// Directives
+using rclcpp::executors::PPE::ThreadDispatchExecutor;
+using rclcpp::executors::thread_priority_range_t;
+using rclcpp::executors::Callback;
+using Callback_Ptr = std::shared_ptr<Callback>;
+
+/*
+ *******************************************************************************
+ *                             Symbolic Constants                              *
+ *******************************************************************************
+*/
+
+
+#define CORE_EXEC        0        // Executor (scheduler) core
+#define CORE_WORK        1        // Job-process core
+
+//#define DEBUG                     // Performs cout logging if enabled
+
+//#define PROFILE                   // Enables profiling, written to cout   
+
+/*
+ *******************************************************************************
+ *                           Constructor/Destructor                            *
+ *******************************************************************************
+*/
+
+
+ThreadDispatchExecutor::ThreadDispatchExecutor (
+	const rclcpp::ExecutorOptions &options,
+	thread_priority_range_t priority_range)
+:
+	rclcpp::Executor(options),
+	d_priority_range(priority_range)
+{
+	// Check: Valid priority range
+	if ((priority_range.u_bound - priority_range.l_bound) < 1) {
+		throw std::invalid_argument(std::string("Bad priority range: ") +
+			std::string("(u_bound - l_bound) must be >= 1"));
+	}
+
+	// Check: Range makes sense for linux
+	if (priority_range.u_bound > 99 || priority_range.l_bound < 0) {
+		throw std::invalid_argument(std::string("Bad priority range: ") +
+			std::string("u_bound must be <= 99 and l_bound >= 0"));
+	}
+}
+
+
+ThreadDispatchExecutor::~ThreadDispatchExecutor ()
+{
+
+}
+
+
+/*
+ *******************************************************************************
+ *                               Public Methods                                *
+ *******************************************************************************
+*/
+
+
+inline void pin_to_core (pthread_t thread, int core, cpu_set_t *cpu_set_p)
+{
+	CPU_ZERO(cpu_set_p);
+	CPU_SET(core, cpu_set_p);
+	if (0 != pthread_setaffinity_np(thread, sizeof(cpu_set_t), cpu_set_p)) {
+		throw std::runtime_error(std::string("pthread_setaffinity_np: ") +
+			std::string(std::strerror(errno)));
+	}
+}
+
+
+inline void set_thread_priority (pthread_t thread, int priority, int *policy_p, 
+	sched_param *sch_p)
+{
+	pthread_getschedparam(thread, policy_p, sch_p);
+	sch_p->sched_priority = priority;
+	if (0 != pthread_setschedparam(thread, SCHED_FIFO, sch_p)) {
+		throw std::runtime_error(std::string("pthread_setschedparam: ") + 
+			std::string(std::strerror(errno)));
+	}
+}
+
+
+void ThreadDispatchExecutor::spin ()
+{
+	spin_some(std::chrono::nanoseconds(0));
+}
+
+
+void ThreadDispatchExecutor::spin_some (std::chrono::nanoseconds max_duration)
+{
+	// Variables for core affinity and process priority
+	sched_param sch, sch_old;
+	int policy, policy_old;
+	cpu_set_t cpu_set;
+
+	// Print description
+	std::cout << std::string("\033[1;33m") + this->description() + std::string("\033[0m\n");
+
+	// Check: Not already spinning
+	if (true == spinning.exchange(true)) {
+		throw std::runtime_error("May not call spin() while already spinning!");
+	}
+
+	// Defer: On exit of this method scope, stop spinning
+	RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
+
+	// Get the current policy and save it
+	pthread_getschedparam(pthread_self(), &policy, &sch);
+	policy_old = policy; 
+	sch_old = sch;
+	
+	// Set core affinity and priority for current thread under FIFO policy
+	pin_to_core(pthread_self(), CORE_EXEC, &cpu_set);
+	set_thread_priority(pthread_self(), d_priority_range.u_bound, &policy, &sch);
+
+	// Run the multiplexer
+#ifdef DEBUG
+	std::cout << "[Executor]: Now multiplexing ..." << std::endl;
+#endif
+	this->multiplex(max_duration);
+
+	// Restore old policy
+	if (0 != pthread_setschedparam(pthread_self(), policy_old, &sch_old)) {
+		throw std::runtime_error(std::string("thread_setschedparam: ") + 
+			std::string(std::strerror(errno)));
+	}
+}
+
+void ThreadDispatchExecutor::run (rclcpp::executors::PPE::ThreadDispatchExecutor *executor, Callback_Ptr callback)
+{
+
+#ifdef DEBUG
+	std::cout << "[Dispatch thread]: Executing " << callback->description() << std::endl;
+#endif
+	// Execute the AnyExecutable
+	callback->execute();
+
+	// Remove the timer/subscription from the handling set
+	executor->remove_expired_executable(callback);
+
+	// Reset callback group
+	callback->callback_group().reset();	
+}
+
+
+#ifdef PROFILE
+
+extern "C" {
+	#include <syslog.h>
+}
+
+// Total processed callbacks
+long g_n_processed_callbacks;
+
+// Cumulative processing time (ns)
+long long g_cumulative_processing_time_ns;
+
+// Function returning timestamp with nanosecond precision
+long long get_timestamp_ns ()
+{
+	auto timestamp_ns = std::chrono::time_point_cast<std::chrono::nanoseconds>(
+		std::chrono::steady_clock::now());
+	auto value_ns = timestamp_ns.time_since_epoch();
+	return value_ns.count();	
+}
+
+#endif
+
+
+void ThreadDispatchExecutor::multiplex (std::chrono::nanoseconds max_duration)
+{
+	int policy;
+	sched_param sch;
+	cpu_set_t cpu_set;
+	std::vector<AnyExecutable> ready_executables;
+	int max_allowed_priority = d_priority_range.u_bound - 
+		d_priority_range.l_bound - 1;
+
+	// Setup
+	pthread_getschedparam(pthread_self(), &policy, &sch);
+
+	// Mark start
+	auto start = std::chrono::steady_clock::now();
+
+	// Create callback for checking time
+	auto should_still_spin = [max_duration, start]() {
+		if (std::chrono::nanoseconds(0) == max_duration) return true;
+		return ((std::chrono::steady_clock::now() - start) < max_duration);
+	};
+
+	// Spin indefinitely, or for a duration if specified
+	while (rclcpp::ok(this->context_) && spinning.load() && 
+		true == should_still_spin())
+	{
+		// Wait for work up to a timeout
+		wait_for_work(std::chrono::nanoseconds(100000000));
+
+		// Check if timeout occurred or should stop spinning
+		if (false == spinning.load() || !should_still_spin()) {
+			break;
+		}
+
+		// Clear and fetch new ready executables
+#ifdef PROFILE
+		long long processing_start_time_ns = get_timestamp_ns();
+#endif
+		ready_executables.clear();
+		memory_strategy_->get_all_ready_timers(&ready_executables, weak_nodes_);
+		memory_strategy_->get_all_ready_subscriptions(&ready_executables, weak_nodes_);
+
+		// Launch a thread for each ready executable
+		for (auto e : ready_executables) {
+			Callback_Ptr item = executable_to_callback(e);
+
+			// If nullptr, then already handled
+			if (item == nullptr) {
+				continue;
+			}
+
+			// Check the priority value
+			if (e.callback_priority < 0 || e.callback_priority > max_allowed_priority) {
+				throw std::runtime_error("Executable had invalid priority: " + 
+					std::to_string(e.callback_priority) + ", only allowed [0," + 
+					std::to_string(max_allowed_priority) + ")");
+			}
+
+			// Prepare the thread
+			std::thread t(std::move(ThreadDispatchExecutor::run), this, item);
+			set_thread_priority(t.native_handle(), d_priority_range.l_bound + e.callback_priority, &policy, &sch);
+			pin_to_core(t.native_handle(), CORE_WORK, &cpu_set);
+			t.detach();
+		}
+
+#ifdef PROFILE
+		long long processing_time_duration_ns = get_timestamp_ns() - processing_start_time_ns;
+		if (ready_executables.size() > 0) {
+			g_n_processed_callbacks += ready_executables.size();
+			g_cumulative_processing_time_ns += processing_time_duration_ns;
+		}
+#endif
+	}
+
+#ifdef PROFILE
+	long long avg_processing_time = g_cumulative_processing_time_ns / g_n_processed_callbacks;
+	syslog(LOG_INFO, "{.value: %lld, .mode: 2}", avg_processing_time);
+#endif
+}
+
+
+Callback_Ptr ThreadDispatchExecutor::executable_to_callback (AnyExecutable e)
+{
+	Callback_Ptr callback = nullptr;
+
+	// Only make a callback if the timer isn't already in the handled set
+	if (nullptr != e.timer) {
+		std::lock_guard<std::mutex> temp_lock(d_timer_set_mutex);
+		if (0 < d_handled_timers.count(e.timer)) {
+			if (nullptr != e.callback_group) {
+				e.callback_group->can_be_taken_from().store(true);
+			}
+		} else {
+			callback = std::make_shared<Callback>(e.timer, e.callback_group, e.node_base);
+			d_handled_timers.insert(e.timer);
+		}
+
+	// Only make a callback if the subscription isn't already in the handled set
+	} else if (nullptr != e.subscription) {
+		std::lock_guard<std::mutex> temp_lock(d_subscription_set_mutex);
+		if (0 == d_handled_subscriptions.count(e.subscription)) {
+			callback = std::make_shared<Callback>(e.subscription, e.callback_group, e.node_base);
+			d_handled_subscriptions.insert(e.subscription);
+		}
+	} else {
+		throw std::runtime_error(std::string("Unsupported executable type: ") +
+			std::string("Only timers and subscription callbacks accepted"));
+	}
+
+	return callback;
+}
+
+
+void ThreadDispatchExecutor::remove_expired_executable (Callback_Ptr callback)
+{
+	switch (callback->callback_type()) {
+		case CALLBACK_TIMER: {
+			std::lock_guard<std::mutex> temp_lock(d_timer_set_mutex);
+			auto t = d_handled_timers.find(callback->timer());
+			if (t != d_handled_timers.end()) {
+				d_handled_timers.erase(t);
+			}
+		}
+		break;
+
+		case CALLBACK_SUBSCRIPTION: {
+			std::lock_guard<std::mutex> temp_lock(d_subscription_set_mutex);
+			auto s = d_handled_subscriptions.find(callback->subscription());
+			if (s != d_handled_subscriptions.end()) {
+				d_handled_subscriptions.erase(s);
+			}
+		}
+		break;
+
+		default: {
+			throw std::runtime_error(
+				std::string("Cannot remove unknown callback type!"));
+		}
+	}
+}
+
+
+std::string ThreadDispatchExecutor::description ()
+{
+	std::string s("Thread-Dispatch-Executor (PPE-TD) {.prio_range = [");
+	s += std::to_string(d_priority_range.l_bound);
+	s += std::string(",");
+	s += std::to_string(d_priority_range.u_bound);
+	s += std::string(")}");
+	return s;
+}


### PR DESCRIPTION
This set of commits reforms the existing executors into two variants. These are (1) The producer-consumer executor, which is based on a fixed set of consumer threads, and (2) thread-dispatch executor, which dispatches dedicated threads to execute callbacks. 

Some namespace reforms have also been adopted.